### PR TITLE
Optimization and compatibility fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ hs_err_pid*
 /build/
 /eclipse/
 /run/
+/.idea/
+/out/
+*.iml
 *.launch
 .settings
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ minecraft {
     version = "1.12-14.21.1.2387"
     runDir = "run"
 
-    mappings = "snapshot_20170624"
+    mappings = "snapshot_20170825"
 }
 
 dependencies {

--- a/src/main/java/xbony2/longfallboots/ItemLongFallBoots.java
+++ b/src/main/java/xbony2/longfallboots/ItemLongFallBoots.java
@@ -16,5 +16,4 @@ public class ItemLongFallBoots extends ItemArmor {
 		this.setRegistryName("longfallboots");
 		this.setUnlocalizedName("longfallboots");
 	}
-
 }

--- a/src/main/java/xbony2/longfallboots/ItemLongFallBoots.java
+++ b/src/main/java/xbony2/longfallboots/ItemLongFallBoots.java
@@ -1,15 +1,13 @@
 package xbony2.longfallboots;
 
 import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemArmor;
-import net.minecraft.item.ItemStack;
-import net.minecraft.world.World;
 import net.minecraftforge.common.util.EnumHelper;
 
 public class ItemLongFallBoots extends ItemArmor {
+
 	public static final ArmorMaterial MATERIAL = EnumHelper.addArmorMaterial("longfallboots", "longfallboots:longfallboots", 66, new int[]{3, 8, 6, 6}, 10, SoundEvents.ITEM_ARMOR_EQUIP_GENERIC, 3.0F);
 
 	public ItemLongFallBoots(){
@@ -18,9 +16,5 @@ public class ItemLongFallBoots extends ItemArmor {
 		this.setRegistryName("longfallboots");
 		this.setUnlocalizedName("longfallboots");
 	}
-	
-	@Override
-	public void onArmorTick(World world, EntityPlayer player, ItemStack itemstack){
-		player.fallDistance = itemstack.getItem() == LongFallBoots.longFallBoots ? 1.0f : 0.0f;
-	}
+
 }

--- a/src/main/java/xbony2/longfallboots/LongFallBoots.java
+++ b/src/main/java/xbony2/longfallboots/LongFallBoots.java
@@ -6,8 +6,6 @@ import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.event.RegistryEvent.Register;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.Mod.EventHandler;
-import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -19,22 +17,17 @@ public class LongFallBoots {
 	public static final String MODID = "longfallboots";
 	public static final String VERSION = "1.2.0a";
 	
-	public static Item longFallBoots;
-
-	@EventHandler
-	public static void preInit(FMLPreInitializationEvent event){
-		longFallBoots = new ItemLongFallBoots();
-	}
+	public static final Item LONG_FALL_BOOTS = new ItemLongFallBoots();
 
 	@SubscribeEvent
 	public static void registerItems(Register<Item> event){
-		event.getRegistry().register(longFallBoots);
+		event.getRegistry().register(LONG_FALL_BOOTS);
 	}
 
 	@SideOnly(Side.CLIENT)
 	@SubscribeEvent
 	public static void registerModels(ModelRegistryEvent event){
-		ModelLoader.setCustomModelResourceLocation(longFallBoots, 0, new ModelResourceLocation(longFallBoots.getRegistryName(), "inventory"));
+		ModelLoader.setCustomModelResourceLocation(LONG_FALL_BOOTS, 0, new ModelResourceLocation(LONG_FALL_BOOTS.getRegistryName(), "inventory"));
 	}
 
 }

--- a/src/main/java/xbony2/longfallboots/LongFallBoots.java
+++ b/src/main/java/xbony2/longfallboots/LongFallBoots.java
@@ -3,11 +3,10 @@ package xbony2.longfallboots;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
-import net.minecraft.util.DamageSource;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.event.RegistryEvent.Register;
-import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
@@ -34,9 +33,9 @@ public class LongFallBoots {
 	}
 
 	@SubscribeEvent
-	public static void onLivingHurt(LivingHurtEvent event) {
-		if (event.getSource().equals(DamageSource.FALL) && event.getEntityLiving().getItemStackFromSlot(EntityEquipmentSlot.FEET).getItem() instanceof ItemLongFallBoots)
-			event.setAmount(0);
+	public static void onLivingFall(LivingFallEvent event) {
+		if (event.getEntityLiving().getItemStackFromSlot(EntityEquipmentSlot.FEET).getItem() instanceof ItemLongFallBoots)
+			event.setDamageMultiplier(0);
 	}
 
 }

--- a/src/main/java/xbony2/longfallboots/LongFallBoots.java
+++ b/src/main/java/xbony2/longfallboots/LongFallBoots.java
@@ -20,13 +20,13 @@ public class LongFallBoots {
 	public static final Item LONG_FALL_BOOTS = new ItemLongFallBoots();
 
 	@SubscribeEvent
-	public static void registerItems(Register<Item> event){
+	public static void onItemRegistry(Register<Item> event){
 		event.getRegistry().register(LONG_FALL_BOOTS);
 	}
 
 	@SideOnly(Side.CLIENT)
 	@SubscribeEvent
-	public static void registerModels(ModelRegistryEvent event){
+	public static void onModelRegistry(ModelRegistryEvent event){
 		ModelLoader.setCustomModelResourceLocation(LONG_FALL_BOOTS, 0, new ModelResourceLocation(LONG_FALL_BOOTS.getRegistryName(), "inventory"));
 	}
 

--- a/src/main/java/xbony2/longfallboots/LongFallBoots.java
+++ b/src/main/java/xbony2/longfallboots/LongFallBoots.java
@@ -1,10 +1,13 @@
 package xbony2.longfallboots;
 
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.event.RegistryEvent.Register;
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
@@ -28,6 +31,12 @@ public class LongFallBoots {
 	@SubscribeEvent
 	public static void onModelRegistry(ModelRegistryEvent event){
 		ModelLoader.setCustomModelResourceLocation(LONG_FALL_BOOTS, 0, new ModelResourceLocation(LONG_FALL_BOOTS.getRegistryName(), "inventory"));
+	}
+
+	@SubscribeEvent
+	public static void onLivingHurt(LivingHurtEvent event) {
+		if (event.getSource().equals(DamageSource.FALL) && event.getEntityLiving().getItemStackFromSlot(EntityEquipmentSlot.FEET).getItem() instanceof ItemLongFallBoots)
+			event.setAmount(0);
 	}
 
 }

--- a/src/main/java/xbony2/longfallboots/LongFallBoots.java
+++ b/src/main/java/xbony2/longfallboots/LongFallBoots.java
@@ -8,14 +8,14 @@ import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.event.RegistryEvent.Register;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 @Mod(modid = LongFallBoots.MODID, version = LongFallBoots.VERSION, dependencies = LongFallBoots.DEPENDENCIES)
-@Mod.EventBusSubscriber(modid = LongFallBoots.MODID)
+@EventBusSubscriber(modid = LongFallBoots.MODID)
 public class LongFallBoots {
-
 	public static final String MODID = "longfallboots";
 	public static final String VERSION = "1.2.0a";
 	public static final String DEPENDENCIES = "required-after:forge@[14.21.1.2387,)";
@@ -38,5 +38,4 @@ public class LongFallBoots {
 		if (event.getEntityLiving().getItemStackFromSlot(EntityEquipmentSlot.FEET).getItem() instanceof ItemLongFallBoots)
 			event.setDamageMultiplier(0);
 	}
-
 }

--- a/src/main/java/xbony2/longfallboots/LongFallBoots.java
+++ b/src/main/java/xbony2/longfallboots/LongFallBoots.java
@@ -12,12 +12,13 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-@Mod(modid = LongFallBoots.MODID, version = LongFallBoots.VERSION)
+@Mod(modid = LongFallBoots.MODID, version = LongFallBoots.VERSION, dependencies = LongFallBoots.DEPENDENCIES)
 @Mod.EventBusSubscriber(modid = LongFallBoots.MODID)
 public class LongFallBoots {
 
 	public static final String MODID = "longfallboots";
 	public static final String VERSION = "1.2.0a";
+	public static final String DEPENDENCIES = "required-after:forge@[14.21.1.2387,)";
 	
 	public static final Item LONG_FALL_BOOTS = new ItemLongFallBoots();
 

--- a/src/main/java/xbony2/longfallboots/LongFallBoots.java
+++ b/src/main/java/xbony2/longfallboots/LongFallBoots.java
@@ -4,38 +4,37 @@ import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.item.Item;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ModelLoader;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.RegistryEvent.Register;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
-import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 @Mod(modid = LongFallBoots.MODID, version = LongFallBoots.VERSION)
+@Mod.EventBusSubscriber(modid = LongFallBoots.MODID)
 public class LongFallBoots {
+
 	public static final String MODID = "longfallboots";
 	public static final String VERSION = "1.2.0a";
 	
 	public static Item longFallBoots;
 
 	@EventHandler
-	public void preInit(FMLPreInitializationEvent event){
+	public static void preInit(FMLPreInitializationEvent event){
 		longFallBoots = new ItemLongFallBoots();
-		MinecraftForge.EVENT_BUS.register(this); //This gets stupider and stupider every version.
 	}
-	
+
 	@SubscribeEvent
-	public void registerItems(Register<Item> event){
+	public static void registerItems(Register<Item> event){
 		event.getRegistry().register(longFallBoots);
 	}
-	
+
 	@SideOnly(Side.CLIENT)
 	@SubscribeEvent
-	public void registerModels(ModelRegistryEvent event){
+	public static void registerModels(ModelRegistryEvent event){
 		ModelLoader.setCustomModelResourceLocation(longFallBoots, 0, new ModelResourceLocation(longFallBoots.getRegistryName(), "inventory"));
 	}
+
 }


### PR DESCRIPTION
- Replaced old event bus method with the cleaner annotation system
- Re-factored event method names to fit with Java standards
- Removed preInit hook setting the Item field. It's not needed, at all.
- Replaced current implementation of fall damage negation with a LivingFallEvent hook

  - More compatible with other mods that rely on fall distance as a calculation variable
  - More optimized than setting the same value every tick