### PR TITLE
Replace String.format with concatenation

### DIFF
--- a/src/main/java/xbony2/longfallboots/LongFallBoots.java
+++ b/src/main/java/xbony2/longfallboots/LongFallBoots.java
@@ -57,7 +57,7 @@ public final class LongFallBoots {
 
 				@Override
 				public String getName() {
-					return String.format("%1$s:%1$s", LONGFALLBOOTS);
+					return LONGFALLBOOTS + ':' + LONGFALLBOOTS;
 				}
 
 				@Override


### PR DESCRIPTION
Not sure why I used `String.format` here, and upon review, it was a poor choice as it has the potential to significantly impact overhead. This getter is called during rendering to compute the texture path, so the less overhead the better. Replacing it with concatenation of 3 constants is as good as it'll get - it compiles to a single constant `"longfallboots:longfallboots"`. Apologies for not realizing this before making the original pull request.